### PR TITLE
Add grant for GM_xmlhttpRequest

### DIFF
--- a/synccit.user.js
+++ b/synccit.user.js
@@ -13,6 +13,7 @@
 // @include       https://reddit.com/*
 // @downloadURL	  https://github.com/drakeapps/synccit-browser-extension/raw/master/synccit.user.js
 // @updateURL	  https://github.com/drakeapps/synccit-browser-extension/raw/master/synccit.user.js
+// @grant         GM_xmlhttpRequest
 // ==/UserScript==
 // 
 


### PR DESCRIPTION
I'm not sure how this has ever worked, according to [this blog post](http://www.greasespot.net/2014/06/sandbox-api-changes-in-greasemonkey-20.html) it's been required for more than 3 years.